### PR TITLE
Addresses #7: Adapted search to use SearchGUI + Comet

### DIFF
--- a/xt-msgf-nf/test/search_gui_params.par
+++ b/xt-msgf-nf/test/search_gui_params.par
@@ -1,0 +1,1430 @@
+{
+  "marshallableParameterType": "identification_parameters",
+  "name": "search_gui_params.xml",
+  "description": "Fixed: Carbamidomethylation of C.\nVariable: Oxidation of M, Acetylation of peptide N-term.\nPrecursor Tolerance: 0.1 ppm.\nDB: db_concatenated_target_decoy.fasta.\n",
+  "defaultDescription": true,
+  "searchParameters": {
+    "precursorAccuracyType": "PPM",
+    "fragmentAccuracyType": "DA",
+    "precursorTolerance": 10,
+    "precursorToleranceDalton": 0.5,
+    "fragmentIonMZTolerance": 0.5,
+    "ptmSettings": {
+      "fixedModifications": [
+        "Carbamidomethylation of C"
+      ],
+      "variableModifications": [
+        "Oxidation of M",
+        "Acetylation of peptide N-term"
+      ],
+      "refinementVariableModifications": [],
+      "refinementFixedModifications": [],
+      "colors": {},
+      "backUp": {
+        "Oxidation of M": {
+          "type": 0,
+          "name": "Oxidation of M",
+          "shortName": "ox",
+          "neutralLosses": [
+            {
+              "composition": {
+                "atomChain": [
+                  {
+                    "atom": {
+                      "type": "com.compomics.util.experiment.biology.atoms.Carbon",
+                      "data": {
+                        "monoisotopicMass": 12.0,
+                        "isotopeMap": {
+                          "-1": 11.0114336,
+                          "0": 12.0,
+                          "-2": 10.0168532,
+                          "1": 13.0033548378,
+                          "-3": 9.0310367,
+                          "2": 14.003241989,
+                          "-4": 8.037675,
+                          "3": 15.0105993,
+                          "4": 16.014701,
+                          "5": 17.022586,
+                          "6": 18.02676,
+                          "7": 19.03481,
+                          "8": 20.04032,
+                          "9": 21.04934,
+                          "10": 22.0572
+                        },
+                        "representativeComposition": {
+                          "0": 0.9893,
+                          "1": 0.0107
+                        },
+                        "name": "Carbon",
+                        "letter": "C"
+                      }
+                    },
+                    "isotope": 0
+                  },
+                  {
+                    "atom": {
+                      "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                      "data": {
+                        "monoisotopicMass": 1.00782503207,
+                        "isotopeMap": {
+                          "0": 1.00782503207,
+                          "1": 2.0141017778
+                        },
+                        "representativeComposition": {
+                          "0": 0.999885,
+                          "1": 1.15E-4
+                        },
+                        "name": "Hydrogen",
+                        "letter": "H"
+                      }
+                    },
+                    "isotope": 0
+                  },
+                  {
+                    "atom": {
+                      "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                      "data": {
+                        "monoisotopicMass": 1.00782503207,
+                        "isotopeMap": {
+                          "0": 1.00782503207,
+                          "1": 2.0141017778
+                        },
+                        "representativeComposition": {
+                          "0": 0.999885,
+                          "1": 1.15E-4
+                        },
+                        "name": "Hydrogen",
+                        "letter": "H"
+                      }
+                    },
+                    "isotope": 0
+                  },
+                  {
+                    "atom": {
+                      "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                      "data": {
+                        "monoisotopicMass": 1.00782503207,
+                        "isotopeMap": {
+                          "0": 1.00782503207,
+                          "1": 2.0141017778
+                        },
+                        "representativeComposition": {
+                          "0": 0.999885,
+                          "1": 1.15E-4
+                        },
+                        "name": "Hydrogen",
+                        "letter": "H"
+                      }
+                    },
+                    "isotope": 0
+                  },
+                  {
+                    "atom": {
+                      "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                      "data": {
+                        "monoisotopicMass": 1.00782503207,
+                        "isotopeMap": {
+                          "0": 1.00782503207,
+                          "1": 2.0141017778
+                        },
+                        "representativeComposition": {
+                          "0": 0.999885,
+                          "1": 1.15E-4
+                        },
+                        "name": "Hydrogen",
+                        "letter": "H"
+                      }
+                    },
+                    "isotope": 0
+                  },
+                  {
+                    "atom": {
+                      "type": "com.compomics.util.experiment.biology.atoms.Oxygen",
+                      "data": {
+                        "monoisotopicMass": 15.99491461956,
+                        "isotopeMap": {
+                          "-1": 15.0030656,
+                          "0": 15.99491461956,
+                          "-2": 14.00859625,
+                          "1": 16.9991317,
+                          "-3": 13.024812,
+                          "2": 17.999161,
+                          "-4": 12.034405,
+                          "3": 19.00358,
+                          "4": 20.0040767,
+                          "5": 21.008656,
+                          "6": 22.00997,
+                          "7": 23.01569,
+                          "8": 24.02047
+                        },
+                        "representativeComposition": {
+                          "0": 0.99757,
+                          "1": 3.8E-4,
+                          "2": 0.00205
+                        },
+                        "name": "Oxygen",
+                        "letter": "O"
+                      }
+                    },
+                    "isotope": 0
+                  },
+                  {
+                    "atom": {
+                      "type": "com.compomics.util.experiment.biology.atoms.Sulfur",
+                      "data": {
+                        "monoisotopicMass": 31.972071,
+                        "isotopeMap": {
+                          "-1": 30.9795547,
+                          "0": 31.972071,
+                          "-2": 29.984903,
+                          "1": 32.97145876,
+                          "-3": 28.99661,
+                          "2": 33.9678669,
+                          "-4": 28.00437,
+                          "3": 34.96903216,
+                          "-5": 27.01883,
+                          "4": 35.96708076,
+                          "-6": 26.02788,
+                          "5": 36.97112557,
+                          "6": 37.971163,
+                          "7": 38.97513,
+                          "8": 39.97545,
+                          "9": 40.97958,
+                          "10": 41.98102,
+                          "11": 42.98715,
+                          "12": 43.99021,
+                          "13": 44.99651,
+                          "14": 47.00859,
+                          "15": 48.01417,
+                          "16": 49.02362
+                        },
+                        "representativeComposition": {
+                          "0": 0.9493,
+                          "1": 0.0076,
+                          "2": 0.0429,
+                          "4": 2.0E-4
+                        },
+                        "name": "Sulfur",
+                        "letter": "S"
+                      }
+                    },
+                    "isotope": 0
+                  }
+                ],
+                "addition": true
+              },
+              "name": "CH4OS",
+              "fixed": false
+            }
+          ],
+          "reporterIons": [],
+          "pattern": {
+            "target": 0,
+            "length": 1,
+            "residueTargeted": {
+              "0": [
+                "M"
+              ]
+            }
+          },
+          "atomChainAdded": {
+            "atomChain": [
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Oxygen",
+                  "data": {
+                    "monoisotopicMass": 15.99491461956,
+                    "isotopeMap": {
+                      "-1": 15.0030656,
+                      "0": 15.99491461956,
+                      "-2": 14.00859625,
+                      "1": 16.9991317,
+                      "-3": 13.024812,
+                      "2": 17.999161,
+                      "-4": 12.034405,
+                      "3": 19.00358,
+                      "4": 20.0040767,
+                      "5": 21.008656,
+                      "6": 22.00997,
+                      "7": 23.01569,
+                      "8": 24.02047
+                    },
+                    "representativeComposition": {
+                      "0": 0.99757,
+                      "1": 3.8E-4,
+                      "2": 0.00205
+                    },
+                    "name": "Oxygen",
+                    "letter": "O"
+                  }
+                },
+                "isotope": 0
+              }
+            ],
+            "addition": true
+          },
+          "cvTerm": {
+            "ontology": "UNIMOD",
+            "accession": "UNIMOD:35",
+            "name": "Oxidation"
+          }
+        },
+        "Acetylation of peptide N-term": {
+          "type": 5,
+          "name": "Acetylation of peptide N-term",
+          "shortName": "ace",
+          "neutralLosses": [],
+          "reporterIons": [],
+          "atomChainAdded": {
+            "atomChain": [
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Carbon",
+                  "data": {
+                    "monoisotopicMass": 12.0,
+                    "isotopeMap": {
+                      "-1": 11.0114336,
+                      "0": 12.0,
+                      "-2": 10.0168532,
+                      "1": 13.0033548378,
+                      "-3": 9.0310367,
+                      "2": 14.003241989,
+                      "-4": 8.037675,
+                      "3": 15.0105993,
+                      "4": 16.014701,
+                      "5": 17.022586,
+                      "6": 18.02676,
+                      "7": 19.03481,
+                      "8": 20.04032,
+                      "9": 21.04934,
+                      "10": 22.0572
+                    },
+                    "representativeComposition": {
+                      "0": 0.9893,
+                      "1": 0.0107
+                    },
+                    "name": "Carbon",
+                    "letter": "C"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Carbon",
+                  "data": {
+                    "monoisotopicMass": 12.0,
+                    "isotopeMap": {
+                      "-1": 11.0114336,
+                      "0": 12.0,
+                      "-2": 10.0168532,
+                      "1": 13.0033548378,
+                      "-3": 9.0310367,
+                      "2": 14.003241989,
+                      "-4": 8.037675,
+                      "3": 15.0105993,
+                      "4": 16.014701,
+                      "5": 17.022586,
+                      "6": 18.02676,
+                      "7": 19.03481,
+                      "8": 20.04032,
+                      "9": 21.04934,
+                      "10": 22.0572
+                    },
+                    "representativeComposition": {
+                      "0": 0.9893,
+                      "1": 0.0107
+                    },
+                    "name": "Carbon",
+                    "letter": "C"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                  "data": {
+                    "monoisotopicMass": 1.00782503207,
+                    "isotopeMap": {
+                      "0": 1.00782503207,
+                      "1": 2.0141017778
+                    },
+                    "representativeComposition": {
+                      "0": 0.999885,
+                      "1": 1.15E-4
+                    },
+                    "name": "Hydrogen",
+                    "letter": "H"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                  "data": {
+                    "monoisotopicMass": 1.00782503207,
+                    "isotopeMap": {
+                      "0": 1.00782503207,
+                      "1": 2.0141017778
+                    },
+                    "representativeComposition": {
+                      "0": 0.999885,
+                      "1": 1.15E-4
+                    },
+                    "name": "Hydrogen",
+                    "letter": "H"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Oxygen",
+                  "data": {
+                    "monoisotopicMass": 15.99491461956,
+                    "isotopeMap": {
+                      "-1": 15.0030656,
+                      "0": 15.99491461956,
+                      "-2": 14.00859625,
+                      "1": 16.9991317,
+                      "-3": 13.024812,
+                      "2": 17.999161,
+                      "-4": 12.034405,
+                      "3": 19.00358,
+                      "4": 20.0040767,
+                      "5": 21.008656,
+                      "6": 22.00997,
+                      "7": 23.01569,
+                      "8": 24.02047
+                    },
+                    "representativeComposition": {
+                      "0": 0.99757,
+                      "1": 3.8E-4,
+                      "2": 0.00205
+                    },
+                    "name": "Oxygen",
+                    "letter": "O"
+                  }
+                },
+                "isotope": 0
+              }
+            ],
+            "addition": true
+          },
+          "cvTerm": {
+            "ontology": "UNIMOD",
+            "accession": "UNIMOD:1",
+            "name": "Acetyl"
+          }
+        },
+        "Carbamidomethylation of C": {
+          "type": 0,
+          "name": "Carbamidomethylation of C",
+          "shortName": "cmm",
+          "neutralLosses": [],
+          "reporterIons": [],
+          "pattern": {
+            "target": 0,
+            "length": 1,
+            "residueTargeted": {
+              "0": [
+                "C"
+              ]
+            }
+          },
+          "atomChainAdded": {
+            "atomChain": [
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Carbon",
+                  "data": {
+                    "monoisotopicMass": 12.0,
+                    "isotopeMap": {
+                      "-1": 11.0114336,
+                      "0": 12.0,
+                      "-2": 10.0168532,
+                      "1": 13.0033548378,
+                      "-3": 9.0310367,
+                      "2": 14.003241989,
+                      "-4": 8.037675,
+                      "3": 15.0105993,
+                      "4": 16.014701,
+                      "5": 17.022586,
+                      "6": 18.02676,
+                      "7": 19.03481,
+                      "8": 20.04032,
+                      "9": 21.04934,
+                      "10": 22.0572
+                    },
+                    "representativeComposition": {
+                      "0": 0.9893,
+                      "1": 0.0107
+                    },
+                    "name": "Carbon",
+                    "letter": "C"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Carbon",
+                  "data": {
+                    "monoisotopicMass": 12.0,
+                    "isotopeMap": {
+                      "-1": 11.0114336,
+                      "0": 12.0,
+                      "-2": 10.0168532,
+                      "1": 13.0033548378,
+                      "-3": 9.0310367,
+                      "2": 14.003241989,
+                      "-4": 8.037675,
+                      "3": 15.0105993,
+                      "4": 16.014701,
+                      "5": 17.022586,
+                      "6": 18.02676,
+                      "7": 19.03481,
+                      "8": 20.04032,
+                      "9": 21.04934,
+                      "10": 22.0572
+                    },
+                    "representativeComposition": {
+                      "0": 0.9893,
+                      "1": 0.0107
+                    },
+                    "name": "Carbon",
+                    "letter": "C"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                  "data": {
+                    "monoisotopicMass": 1.00782503207,
+                    "isotopeMap": {
+                      "0": 1.00782503207,
+                      "1": 2.0141017778
+                    },
+                    "representativeComposition": {
+                      "0": 0.999885,
+                      "1": 1.15E-4
+                    },
+                    "name": "Hydrogen",
+                    "letter": "H"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                  "data": {
+                    "monoisotopicMass": 1.00782503207,
+                    "isotopeMap": {
+                      "0": 1.00782503207,
+                      "1": 2.0141017778
+                    },
+                    "representativeComposition": {
+                      "0": 0.999885,
+                      "1": 1.15E-4
+                    },
+                    "name": "Hydrogen",
+                    "letter": "H"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                  "data": {
+                    "monoisotopicMass": 1.00782503207,
+                    "isotopeMap": {
+                      "0": 1.00782503207,
+                      "1": 2.0141017778
+                    },
+                    "representativeComposition": {
+                      "0": 0.999885,
+                      "1": 1.15E-4
+                    },
+                    "name": "Hydrogen",
+                    "letter": "H"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Nitrogen",
+                  "data": {
+                    "monoisotopicMass": 14.0030740048,
+                    "isotopeMap": {
+                      "-1": 13.00573861,
+                      "0": 14.0030740048,
+                      "-2": 12.0186132,
+                      "1": 15.0001088982,
+                      "-3": 11.02609,
+                      "2": 16.0061017,
+                      "-4": 10.04165,
+                      "3": 17.00845,
+                      "4": 18.014079,
+                      "5": 19.017029,
+                      "6": 20.02337,
+                      "7": 21.02711,
+                      "8": 22.03439,
+                      "9": 23.04122,
+                      "10": 24.05104,
+                      "11": 25.06066
+                    },
+                    "representativeComposition": {
+                      "0": 0.99636,
+                      "1": 0.00364
+                    },
+                    "name": "Nitrogen",
+                    "letter": "N"
+                  }
+                },
+                "isotope": 0
+              },
+              {
+                "atom": {
+                  "type": "com.compomics.util.experiment.biology.atoms.Oxygen",
+                  "data": {
+                    "monoisotopicMass": 15.99491461956,
+                    "isotopeMap": {
+                      "-1": 15.0030656,
+                      "0": 15.99491461956,
+                      "-2": 14.00859625,
+                      "1": 16.9991317,
+                      "-3": 13.024812,
+                      "2": 17.999161,
+                      "-4": 12.034405,
+                      "3": 19.00358,
+                      "4": 20.0040767,
+                      "5": 21.008656,
+                      "6": 22.00997,
+                      "7": 23.01569,
+                      "8": 24.02047
+                    },
+                    "representativeComposition": {
+                      "0": 0.99757,
+                      "1": 3.8E-4,
+                      "2": 0.00205
+                    },
+                    "name": "Oxygen",
+                    "letter": "O"
+                  }
+                },
+                "isotope": 0
+              }
+            ],
+            "addition": true
+          },
+          "cvTerm": {
+            "ontology": "UNIMOD",
+            "accession": "UNIMOD:4",
+            "name": "Carbamidomethyl"
+          }
+        }
+      }
+    },
+    "enzyme": {
+      "id": 0,
+      "name": "Trypsin",
+      "aminoAcidBefore": [
+        "R",
+        "K"
+      ],
+      "aminoAcidAfter": [],
+      "restrictionBefore": [],
+      "restrictionAfter": [
+        "P"
+      ],
+      "isSemiSpecific": false,
+      "isWholeProtein": false
+    },
+    "nMissedCleavages": 2,
+    "fastaFile": {
+      "path": "/data/test/db_concatenated_target_decoy.fasta"
+    },
+    "parametersFile": {},
+    "fractionMolecularWeightRanges": {},
+    "forwardIon": 1,
+    "rewindIon": 4,
+    "minChargeSearched": {
+      "sign": 1,
+      "value": 2
+    },
+    "maxChargeSearched": {
+      "sign": 1,
+      "value": 4
+    },
+    "minIsotopicCorrection": 0,
+    "maxIsotopicCorrection": 1,
+    "algorithmParameters": {
+      "1": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.OmssaParameters",
+        "data": {
+          "maxEValue": 100.0,
+          "hitListLength": 10,
+          "minimalChargeForMultipleChargedFragments": {
+            "sign": 1,
+            "value": 3
+          },
+          "minPeptideLength": 8,
+          "maxPeptideLength": 30,
+          "removePrecursor": false,
+          "scalePrecursor": true,
+          "estimateCharge": true,
+          "selectedOutput": "OMX",
+          "memoryMappedSequenceLibraries": false,
+          "numberOfItotopicPeaks": 0,
+          "neutronThreshold": 1446.94,
+          "lowIntensityCutOff": 0.0,
+          "highIntensityCutOff": 0.2,
+          "intensityCutOffIncrement": 5.0E-4,
+          "singleChargeWindow": 27,
+          "doubleChargeWindow": 14,
+          "nPeaksInSingleChargeWindow": 2,
+          "nPeaksInDoubleChargeWindow": 2,
+          "maxHitsPerSpectrumPerCharge": 30,
+          "nAnnotatedMostIntensePeaks": 6,
+          "minAnnotatedPeaks": 2,
+          "minPeaks": 4,
+          "cleaveNtermMethionine": true,
+          "maxMzLadders": 128,
+          "maxFragmentCharge": 2,
+          "fractionOfPeaksForChargeEstimation": 0.95,
+          "determineChargePlusOneAlgorithmically": true,
+          "searchPositiveIons": true,
+          "minPrecPerSpectrum": 1,
+          "searchForwardFragmentFirst": false,
+          "searchRewindFragments": true,
+          "maxFragmentPerSeries": 100,
+          "useCorrelationCorrectionScore": true,
+          "consecutiveIonProbability": 0.5,
+          "iterativeSequenceEvalue": 0.0,
+          "iterativeReplaceEvalue": 0.0,
+          "iterativeSpectrumEvalue": 0.01,
+          "noProlineRuleSeries": [],
+          "ptmIndexes": {}
+        }
+      },
+      "2": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.XtandemParameters",
+        "data": {
+          "maxEValue": 0.01,
+          "outputResults": "all",
+          "dynamicRange": 100.0,
+          "nPeaks": 50,
+          "minPrecursorMass": 500.0,
+          "minFragmentMz": 200.0,
+          "minPeaksPerSpectrum": 5,
+          "proteinQuickAcetyl": true,
+          "quickPyrolidone": true,
+          "refine": true,
+          "refineSemi": false,
+          "refinePointMutations": false,
+          "refineSpectrumSynthesis": true,
+          "refineUnanticipatedCleavages": true,
+          "refineSnaps": true,
+          "maximumExpectationValueRefinement": 0.01,
+          "potentialModificationsForFullRefinment": false,
+          "skylinePath": "",
+          "outputProteins": true,
+          "outputSequences": false,
+          "outputSpectra": true,
+          "outputHistograms": false,
+          "stpBias": false,
+          "useNoiseSuppression": false,
+          "proteinPtmComplexity": 6.0
+        }
+      },
+      "3": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.PepnovoParameters",
+        "data": {
+          "hitListLength": 10,
+          "estimateCharge": true,
+          "correctPrecursorMass": false,
+          "discardLowQualitySpectra": true,
+          "fragmentationModel": "CID_IT_TRYP",
+          "generateQuery": false
+        }
+      },
+      "4": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.AndromedaParameters",
+        "data": {
+          "maxPeptideMass": 4600.0,
+          "maxCombinations": 250,
+          "topPeaks": 8,
+          "topPeaksWindow": 100,
+          "includeWater": true,
+          "includeAmmonia": true,
+          "dependentLosses": true,
+          "fragmentAll": false,
+          "empiricalCorrection": true,
+          "higherCharge": true,
+          "fragmentationMethod": "CID",
+          "maxNumberOfModifications": 5,
+          "minPeptideLengthNoEnzyme": 8,
+          "maxPeptideLengthNoEnzyme": 25,
+          "equalIL": false,
+          "numberOfCandidates": 10,
+          "ptmIndexes": {}
+        }
+      },
+      "5": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.MsAmandaParameters",
+        "data": {
+          "generateDecoy": false,
+          "instrumentID": "b, y",
+          "maxRank": 10,
+          "monoisotopic": true,
+          "lowMemoryMode": true
+        }
+      },
+      "7": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.MsgfParameters",
+        "data": {
+          "searchDecoyDatabase": false,
+          "instrumentID": 3,
+          "fragmentationType": 3,
+          "protocol": 0,
+          "minPeptideLength": 8,
+          "maxPeptideLength": 30,
+          "numberOfSpectrumMarches": 10,
+          "additionalOutput": false,
+          "lowerIsotopeErrorRange": -1,
+          "upperIsotopeErrorRange": 2,
+          "numberTolerableTermini": 2,
+          "numberOfPtmsPerPeptide": 2
+        }
+      },
+      "8": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.DirecTagParameters",
+        "data": {
+          "ticCutoffPercentage": 85.0,
+          "maxPeakCount": 100,
+          "numIntensityClasses": 3,
+          "adjustPrecursorMass": false,
+          "minPrecursorAdjustment": -2.5,
+          "maxPrecursorAdjustment": 2.5,
+          "precursorAdjustmentStep": 0.1,
+          "numChargeStates": 3,
+          "outputSuffix": "",
+          "useChargeStateFromMS": false,
+          "duplicateSpectra": true,
+          "deisotopingMode": 0,
+          "isotopeMzTolerance": 0.25,
+          "complementMzTolerance": 0.5,
+          "tagLength": 4,
+          "maxDynamicMods": 2,
+          "maxTagCount": 10,
+          "intensityScoreWeight": 1.0,
+          "mzFidelityScoreWeight": 1.0,
+          "complementScoreWeight": 1.0,
+          "variablePtms": []
+        }
+      },
+      "10": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.CometParameters",
+        "data": {
+          "numberOfSpectrumMatches": 10,
+          "maxVariableMods": 10,
+          "requireVariableMods": false,
+          "minPeaks": 10,
+          "minPeakIntensity": 0.0,
+          "removePrecursor": 0,
+          "removePrecursorTolerance": 1.5,
+          "lowerClearMzRange": 0.0,
+          "upperClearMzRange": 0.0,
+          "enzymeType": 2,
+          "isotopeCorrection": 1,
+          "minPrecursorMass": 0.0,
+          "maxPrecursorMass": 10000.0,
+          "maxFragmentCharge": 3,
+          "removeMethionine": false,
+          "batchSize": 0,
+          "theoreticalFragmentIonsSumOnly": false,
+          "fragmentBinOffset": 0.0,
+          "useSparseMatrix": true,
+          "selectedOutputFormat": "PepXML",
+          "printExpectScore": true
+        }
+      },
+      "27": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.PNovoParameters",
+        "data": {
+          "numberOfPeptides": 10,
+          "lowerPrecursorMass": 300,
+          "upperPrecursorMass": 5000,
+          "acticationType": "HCD"
+        }
+      },
+      "28": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.TideParameters",
+        "data": {
+          "fastIndexFolderName": "fasta-index",
+          "maxVariablePtmsPerTypePerPeptide": 2,
+          "minPeptideLength": 6,
+          "maxPeptideLength": 30,
+          "minPrecursorMass": 200.0,
+          "maxPrecursorMass": 7200.0,
+          "decoyFormat": "none",
+          "keepTerminalAminoAcids": "NC",
+          "decoySeed": 1,
+          "outputFolderName": "crux-output",
+          "printPeptides": false,
+          "verbosity": 30,
+          "monoisotopicPrecursor": true,
+          "clipNtermMethionine": false,
+          "digestionType": "full-digest",
+          "computeSpScore": false,
+          "numberOfSpectrumMatches": 10,
+          "computeExactPValues": false,
+          "minSpectrumMz": 0.0,
+          "minSpectrumPeaks": 20,
+          "spectrumCharges": "all",
+          "removePrecursor": false,
+          "removePrecursorTolerance": 1.5,
+          "printProgressIndicatorSize": 1000,
+          "useFlankingPeaks": false,
+          "useNeutralLossPeaks": false,
+          "mzBinWidth": 0.02,
+          "mzBinOffset": 0.0,
+          "concatenateTargetDecoy": false,
+          "textOutput": true,
+          "sqtOutput": false,
+          "pepXmlOutput": false,
+          "mzidOutput": false,
+          "pinOutput": false,
+          "removeTempFolders": true
+        }
+      },
+      "13": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.MyriMatchParameters",
+        "data": {
+          "minPeptideLength": 8,
+          "maxPeptideLength": 30,
+          "numberOfSpectrumMatches": 10,
+          "ticCutoffPercentage": 0.98,
+          "maxDynamicMods": 2,
+          "minTerminiCleavages": 2,
+          "minPrecursorMass": 0.0,
+          "maxPrecursorMass": 10000.0,
+          "useSmartPlusThreeModel": true,
+          "computeXCorr": false,
+          "numIntensityClasses": 3,
+          "classSizeMultiplier": 2,
+          "numberOfBatches": 50,
+          "lowerIsotopeCorrection": -1,
+          "upperIsotopeCorrection": 2,
+          "fragmentationRule": "CID",
+          "maxPeakCount": 300,
+          "outputFormat": "mzIdentML"
+        }
+      },
+      "29": {
+        "type": "com.compomics.util.experiment.identification.identification_parameters.tool_specific.NovorParameters",
+        "data": {
+          "fragmentationMethod": "HCD",
+          "massAnalyzer": "FT"
+        }
+      }
+    }
+  },
+  "annotationSettings": {
+    "yAxisZoomExcludesBackgroundPeaks": true,
+    "showAllPeaks": false,
+    "intensityLimit": 0.75,
+    "automaticAnnotation": true,
+    "selectedIonsMap": {
+      "TAG_FRAGMENT_ION": [
+        1,
+        4
+      ],
+      "RELATED_ION": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18
+      ],
+      "PEPTIDE_FRAGMENT_ION": [
+        1,
+        4
+      ],
+      "PRECURSOR_ION": [
+        0
+      ],
+      "IMMONIUM_ION": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        16,
+        17,
+        18,
+        19,
+        20
+      ],
+      "REPORTER_ION": []
+    },
+    "neutralLossesList": [
+      {
+        "composition": {
+          "atomChain": [
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                "data": {
+                  "monoisotopicMass": 1.00782503207,
+                  "isotopeMap": {
+                    "0": 1.00782503207,
+                    "1": 2.0141017778
+                  },
+                  "representativeComposition": {
+                    "0": 0.999885,
+                    "1": 1.15E-4
+                  },
+                  "name": "Hydrogen",
+                  "letter": "H"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                "data": {
+                  "monoisotopicMass": 1.00782503207,
+                  "isotopeMap": {
+                    "0": 1.00782503207,
+                    "1": 2.0141017778
+                  },
+                  "representativeComposition": {
+                    "0": 0.999885,
+                    "1": 1.15E-4
+                  },
+                  "name": "Hydrogen",
+                  "letter": "H"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Oxygen",
+                "data": {
+                  "monoisotopicMass": 15.99491461956,
+                  "isotopeMap": {
+                    "-1": 15.0030656,
+                    "0": 15.99491461956,
+                    "-2": 14.00859625,
+                    "1": 16.9991317,
+                    "-3": 13.024812,
+                    "2": 17.999161,
+                    "-4": 12.034405,
+                    "3": 19.00358,
+                    "4": 20.0040767,
+                    "5": 21.008656,
+                    "6": 22.00997,
+                    "7": 23.01569,
+                    "8": 24.02047
+                  },
+                  "representativeComposition": {
+                    "0": 0.99757,
+                    "1": 3.8E-4,
+                    "2": 0.00205
+                  },
+                  "name": "Oxygen",
+                  "letter": "O"
+                }
+              },
+              "isotope": 0
+            }
+          ],
+          "addition": true
+        },
+        "name": "H2O",
+        "fixed": false
+      },
+      {
+        "composition": {
+          "atomChain": [
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Nitrogen",
+                "data": {
+                  "monoisotopicMass": 14.0030740048,
+                  "isotopeMap": {
+                    "-1": 13.00573861,
+                    "0": 14.0030740048,
+                    "-2": 12.0186132,
+                    "1": 15.0001088982,
+                    "-3": 11.02609,
+                    "2": 16.0061017,
+                    "-4": 10.04165,
+                    "3": 17.00845,
+                    "4": 18.014079,
+                    "5": 19.017029,
+                    "6": 20.02337,
+                    "7": 21.02711,
+                    "8": 22.03439,
+                    "9": 23.04122,
+                    "10": 24.05104,
+                    "11": 25.06066
+                  },
+                  "representativeComposition": {
+                    "0": 0.99636,
+                    "1": 0.00364
+                  },
+                  "name": "Nitrogen",
+                  "letter": "N"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                "data": {
+                  "monoisotopicMass": 1.00782503207,
+                  "isotopeMap": {
+                    "0": 1.00782503207,
+                    "1": 2.0141017778
+                  },
+                  "representativeComposition": {
+                    "0": 0.999885,
+                    "1": 1.15E-4
+                  },
+                  "name": "Hydrogen",
+                  "letter": "H"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                "data": {
+                  "monoisotopicMass": 1.00782503207,
+                  "isotopeMap": {
+                    "0": 1.00782503207,
+                    "1": 2.0141017778
+                  },
+                  "representativeComposition": {
+                    "0": 0.999885,
+                    "1": 1.15E-4
+                  },
+                  "name": "Hydrogen",
+                  "letter": "H"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                "data": {
+                  "monoisotopicMass": 1.00782503207,
+                  "isotopeMap": {
+                    "0": 1.00782503207,
+                    "1": 2.0141017778
+                  },
+                  "representativeComposition": {
+                    "0": 0.999885,
+                    "1": 1.15E-4
+                  },
+                  "name": "Hydrogen",
+                  "letter": "H"
+                }
+              },
+              "isotope": 0
+            }
+          ],
+          "addition": true
+        },
+        "name": "NH3",
+        "fixed": false
+      },
+      {
+        "composition": {
+          "atomChain": [
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Carbon",
+                "data": {
+                  "monoisotopicMass": 12.0,
+                  "isotopeMap": {
+                    "-1": 11.0114336,
+                    "0": 12.0,
+                    "-2": 10.0168532,
+                    "1": 13.0033548378,
+                    "-3": 9.0310367,
+                    "2": 14.003241989,
+                    "-4": 8.037675,
+                    "3": 15.0105993,
+                    "4": 16.014701,
+                    "5": 17.022586,
+                    "6": 18.02676,
+                    "7": 19.03481,
+                    "8": 20.04032,
+                    "9": 21.04934,
+                    "10": 22.0572
+                  },
+                  "representativeComposition": {
+                    "0": 0.9893,
+                    "1": 0.0107
+                  },
+                  "name": "Carbon",
+                  "letter": "C"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                "data": {
+                  "monoisotopicMass": 1.00782503207,
+                  "isotopeMap": {
+                    "0": 1.00782503207,
+                    "1": 2.0141017778
+                  },
+                  "representativeComposition": {
+                    "0": 0.999885,
+                    "1": 1.15E-4
+                  },
+                  "name": "Hydrogen",
+                  "letter": "H"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                "data": {
+                  "monoisotopicMass": 1.00782503207,
+                  "isotopeMap": {
+                    "0": 1.00782503207,
+                    "1": 2.0141017778
+                  },
+                  "representativeComposition": {
+                    "0": 0.999885,
+                    "1": 1.15E-4
+                  },
+                  "name": "Hydrogen",
+                  "letter": "H"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                "data": {
+                  "monoisotopicMass": 1.00782503207,
+                  "isotopeMap": {
+                    "0": 1.00782503207,
+                    "1": 2.0141017778
+                  },
+                  "representativeComposition": {
+                    "0": 0.999885,
+                    "1": 1.15E-4
+                  },
+                  "name": "Hydrogen",
+                  "letter": "H"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Hydrogen",
+                "data": {
+                  "monoisotopicMass": 1.00782503207,
+                  "isotopeMap": {
+                    "0": 1.00782503207,
+                    "1": 2.0141017778
+                  },
+                  "representativeComposition": {
+                    "0": 0.999885,
+                    "1": 1.15E-4
+                  },
+                  "name": "Hydrogen",
+                  "letter": "H"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Oxygen",
+                "data": {
+                  "monoisotopicMass": 15.99491461956,
+                  "isotopeMap": {
+                    "-1": 15.0030656,
+                    "0": 15.99491461956,
+                    "-2": 14.00859625,
+                    "1": 16.9991317,
+                    "-3": 13.024812,
+                    "2": 17.999161,
+                    "-4": 12.034405,
+                    "3": 19.00358,
+                    "4": 20.0040767,
+                    "5": 21.008656,
+                    "6": 22.00997,
+                    "7": 23.01569,
+                    "8": 24.02047
+                  },
+                  "representativeComposition": {
+                    "0": 0.99757,
+                    "1": 3.8E-4,
+                    "2": 0.00205
+                  },
+                  "name": "Oxygen",
+                  "letter": "O"
+                }
+              },
+              "isotope": 0
+            },
+            {
+              "atom": {
+                "type": "com.compomics.util.experiment.biology.atoms.Sulfur",
+                "data": {
+                  "monoisotopicMass": 31.972071,
+                  "isotopeMap": {
+                    "-1": 30.9795547,
+                    "0": 31.972071,
+                    "-2": 29.984903,
+                    "1": 32.97145876,
+                    "-3": 28.99661,
+                    "2": 33.9678669,
+                    "-4": 28.00437,
+                    "3": 34.96903216,
+                    "-5": 27.01883,
+                    "4": 35.96708076,
+                    "-6": 26.02788,
+                    "5": 36.97112557,
+                    "6": 37.971163,
+                    "7": 38.97513,
+                    "8": 39.97545,
+                    "9": 40.97958,
+                    "10": 41.98102,
+                    "11": 42.98715,
+                    "12": 43.99021,
+                    "13": 44.99651,
+                    "14": 47.00859,
+                    "15": 48.01417,
+                    "16": 49.02362
+                  },
+                  "representativeComposition": {
+                    "0": 0.9493,
+                    "1": 0.0076,
+                    "2": 0.0429,
+                    "4": 2.0E-4
+                  },
+                  "name": "Sulfur",
+                  "letter": "S"
+                }
+              },
+              "isotope": 0
+            }
+          ],
+          "addition": true
+        },
+        "name": "CH4OS",
+        "fixed": false
+      }
+    ],
+    "neutralLossesAuto": true,
+    "reporterIons": true,
+    "relatedIons": true,
+    "fragmentIonAccuracy": 0.5,
+    "fragmentIonPpm": false,
+    "showForwardIonDeNovoTags": false,
+    "showRewindIonDeNovoTags": false,
+    "deNovoCharge": 1,
+    "highResolutionAnnotation": true
+  },
+  "sequenceMatchingPreferences": {
+    "sequenceMatchingType": "indistiguishableAminoAcids",
+    "limitX": 0.25,
+    "peptideMapperType": "tree"
+  },
+  "genePreferences": {},
+  "psmScoringPreferences": {},
+  "peptideAssumptionFilter": {
+    "minPepLength": 8,
+    "maxPepLength": 30,
+    "maxMassDeviation": 0.1,
+    "isPpm": true,
+    "unknownPtm": true,
+    "minIsotopes": 0,
+    "maxIsotopes": 1
+  },
+  "ptmScoringPreferences": {
+    "flr": 1.0,
+    "probabilitsticScoreCalculation": true,
+    "selectedProbabilisticScore": "PhosphoRS",
+    "estimateFlr": false,
+    "probabilisticScoreThreshold": 95.0,
+    "probabilisticScoreNeutralLosses": false,
+    "sequenceMatchingPreferences": {
+      "sequenceMatchingType": "aminoAcid",
+      "peptideMapperType": "tree"
+    }
+  },
+  "proteinInferencePreferences": {
+    "proteinSequenceDatabase": {
+      "path": "/data/test/db_concatenated_target_decoy.fasta"
+    }
+  },
+  "idValidationPreferences": {
+    "defaultProteinFDR": 1.0,
+    "defaultPeptideFDR": 1.0,
+    "defaultPsmFDR": 1.0,
+    "separatePeptides": true,
+    "separatePsms": true,
+    "mergeSmallSubgroups": true,
+    "validationQCPreferences": {
+      "dbSize": false,
+      "firstDecoy": true,
+      "confidenceMargin": 1.0
+    }
+  },
+  "fractionSettings": {
+    "proteinConfidenceMwPlots": 95.0
+  }
+}

--- a/xt-msgf-nf/xt-msgf-nf.nf
+++ b/xt-msgf-nf/xt-msgf-nf.nf
@@ -5,13 +5,8 @@
  */
 params.mgf_dir = "${baseDir}/test"
 params.fasta_file = "${baseDir}/test/uniprot-human-reviewed.fasta"
-
-// X!Tandem template files should not be changed unless for very good reason.
-params.xtandem_template = "${baseDir}/config/input.xml"
-params.xtandem_taxonomy = "${baseDir}/config/taxonomy.xml"
-
-// MGF parameters
-params.msgf_mods = "${baseDir}/config/Mods.txt"
+// SearchGUI parameter file
+params.search_params = "${baseDir}/test/search_gui_params.par"
 
 // PIA Parameters
 params.pia_config = "${baseDir}/config/pia_config.xml"
@@ -44,9 +39,7 @@ params.max_charge = 4
 (mgf_files, mgf_files_msgf) = Channel.fromPath("${params.mgf_dir}/*.mgf").into(2)
 fasta_file = file(params.fasta_file)
 
-xtandem_template = file(params.xtandem_template)
-xtandem_taxonomy = file(params.xtandem_taxonomy)
-msgf_mods = file(params.msgf_mods)
+search_gui_config = file(params.search_params)
 pia_config = file(params.pia_config)
 
 /**
@@ -70,106 +63,71 @@ process createDecoyDb {
 	"""
 }
 
-/**
- * Create the configuration file required to launch X!Tandem
- */
-process createTandemConfig {
+process searchMSGF {
+	container 'biocontainers/searchgui:v2.8.6_cv2'
+	publishDir "result"
+
+	memory '4 GB'
+
 	input:
-	file "settings.xml" from xtandem_template
+	file search_gui_config
+	file fasta_decoy_db
+	file mgf_file from mgf_files_msgf
 
 	output:
-	file "adapted_settings.xml" into xtandem_settings
+	file "${mgf_file}.mzid" into msgf_result, all_msgf_result
 
 	script:
 	"""
-	sed -e 's|FRAG_TOL|${params.frag_tol}|' \
-	    -e 's|PREC_TOL|${params.prec_tol}|' \
-	    -e 's|MISSED_CLEAV|${params.mc}|' \
-	    -e 's|THREADS|$threads|' \
-	    ${xtandem_template} > adapted_settings.xml
+	# fix the fasta file path
+	sed -i 's|"/[^"]*\\.fasta|"${fasta_decoy_db}|' ${search_gui_config}
+
+	# run the search
+	java -Xmx3500M -cp /home/biodocker/bin/SearchGUI-2.8.6/SearchGUI-2.8.6.jar eu.isas.searchgui.cmd.SearchCLI \
+	-spectrum_files ${mgf_file} \
+	-output_folder . \
+	-id_params ${search_gui_config} \
+	-xtandem 0 -msgf 1 -comet 0 -ms_amanda 0 -myrimatch 0 -andromeda 0 -omssa 0 -tide 0
+
+	# extract the mzid file
+	unzip -o searchgui_out.zip
+
+	# simply fix the filename to fit our pattern
+	rename 's/msgf/mgf/' *.mzid
 	"""
 }
 
-/**
- * Search every MGF file using X!Tandem
- */
-process searchTandem {
-	container 'biocontainers/tandem:v17-02-01-4_cv4'
+process searchComet {
+	container 'biocontainers/searchgui:v2.8.6_cv2'
 	publishDir "result"
 
-	memory '5 GB'
+	memory '4 GB'
 
 	input:
-	file xtandem_settings
-	file xtandem_taxonomy
+	file search_gui_config
 	file fasta_decoy_db
 	file mgf_file from mgf_files
 
 	output:
-    file "${mgf_file}.xml.mzid" into xtandem_result
-	file "${mgf_file}.xml" into xtandem_xml_result
-	file "${mgf_file}.xml" into all_xtandem_result
-
-	script:
-	"""
-	sed -e 's|ORG_NAME|${mgf_file}|' ${xtandem_settings} > ${mgf_file}.settings.xml && \
-	tandem ${mgf_file}.settings.xml && \
-	sed -i 's|value="^XXX"|value="_REVERSED"|' ${mgf_file}.xml.mzid
-	"""	
-}
-
-/**
- * Create the MSGF+ database index
- */
-process createMsgfDbIndex {
-	container 'quay.io/biocontainers/msgf_plus:2017.07.21--3'
-	// MSGF+ will raise an exception since the MGF file is empty
-	validExitStatus 0,1
-
-	memory '4 GB'
+	file "${mgf_file}.pep.xml" into comet_xml_result, all_comet_result
 	
-	input:
-	file "user.fasta" from fasta_decoy_db
-
-	output:
-	file "user.*" into msgf_fasta_index
-
 	script:
 	"""
-	touch ./temp.mgf
-	msgf_plus -s ./temp.mgf -d user.fasta -tda 0
-	"""
-}
+	# fix the fasta file path
+	sed -i 's|"/[^"]*\\.fasta|"${fasta_decoy_db}|' ${search_gui_config}
+	
+	# run the search
+	java -Xmx3500M -cp /home/biodocker/bin/SearchGUI-2.8.6/SearchGUI-2.8.6.jar eu.isas.searchgui.cmd.SearchCLI \
+	-spectrum_files ${mgf_file} \
+	-output_folder . \
+	-id_params ${search_gui_config} \
+	-xtandem 0 -msgf 0 -comet 1 -ms_amanda 0 -myrimatch 0 -andromeda 0 -omssa 0 -tide 0
 
-/**
- * Search every MGF file using MSGF+
- * 
- * Notes on parameters:
- *   * -inst 3 = QExactive, 1 = Orbitrap
- *   * -e 1 = Trypsin
- *   * -ntt 2 = Termini
- */
-process searchMsgf {
-	container 'quay.io/biocontainers/msgf_plus:2017.07.21--3'
-	publishDir "result"
+	# extract the result file
+	unzip -o searchgui_out.zip
 
-	memory { 16.GB * task.attempt }
-    errorStrategy 'retry'
-
-	input:
-	file "user.fasta" from fasta_decoy_db
-	file msgf_fasta_index
-	file mgf_file_msgf from mgf_files_msgf
-	file msgf_mods
-
-	output:
-	file "*.mzid" into msgf_result
-	file "*.mzid" into all_msgf_result
-
-	script:
-	"""
-	msgf_plus -Xmx${10 * task.attempt}g -d user.fasta -s ${mgf_file_msgf} -t ${params.prec_tol}ppm -ti 0,1 -thread ${threads} \
-	-tda 0 -inst 3 -e 1 -ntt ${params.mc} -mod ${msgf_mods} -minCharge ${params.min_charge} -maxCharge ${params.max_charge}
+	# rename the result file
+	rename 's|\\.comet|.mgf|' *.comet.pep.xml
 	"""
 }
 
@@ -177,34 +135,34 @@ process searchMsgf {
  * Combine the search results for every MGF files
  */
 // Change each result channel into a set with the base MGF name as the key
-xtandem_key = xtandem_xml_result.map { file ->
-		(whole_name, index) = (file =~ /.*\/(.*)\.mgf\.xml/)[0]
+comet_key = comet_xml_result.map { file ->
+		(whole_name, index) = (file =~ /.*\/(.*)\.mgf\.pep\.xml/)[0]
 		[index, file]
 	}
 msgf_key = msgf_result.map { file ->
-		(whole_name, index) = (file =~ /.*\/(.*)\.mzid/)[0]
+		(whole_name, index) = (file =~ /.*\/(.*)\.mgf\.mzid/)[0]
 		[index, file]
 	}
 
 // merge the results based on the MGF filename as key
-combined_results = xtandem_key.combine(msgf_key, by: 0)
+combined_results = comet_key.combine(msgf_key, by: 0)
 
 process mergeSearchResults {
 	container 'ypriverol/pia:1.3.10'
 	publishDir "result"
 
-	memory { 16.GB * task.attempt }
-    errorStrategy 'retry'
+	memory { 4.GB * task.attempt }
+	errorStrategy 'retry'
 
 	input:
-	set val(mgf_name), file(xtandem_mzid), file(msgf_mzid) from combined_results
+	set val(mgf_name), file(comet_xml), file(msgf_mzid) from combined_results
 
 	output:
 	file "${mgf_name}.xml" into pia_compilation
 
 	script:
 	"""
-	pia -Xmx${10 * task.attempt}g compiler -infile ${xtandem_mzid} -infile ${msgf_mzid} -name "${mgf_name}" -outfile ${mgf_name}.xml
+	pia -Xmx${4 * task.attempt}g compiler -infile ${comet_xml} -infile ${msgf_mzid} -name "${mgf_name}" -outfile ${mgf_name}.xml
 	"""
 }
 
@@ -215,7 +173,7 @@ process filterPiaResults {
 	container 'ypriverol/pia:1.3.10'
 	publishDir "result", mode: 'copy', overwrite: true
 
-	memory { 16.GB * task.attempt }
+	memory { 4.GB * task.attempt }
     errorStrategy 'retry'
 
 	input:
@@ -227,7 +185,7 @@ process filterPiaResults {
 
 	script:
 	"""
-	pia -Xmx${10 * task.attempt}g inference -infile ${pia_xml} -paramFile ${pia_config} -psmExport ${pia_xml}.mztab mzTab
+	pia -Xmx${4 * task.attempt}g inference -infile ${pia_xml} -paramFile ${pia_config} -psmExport ${pia_xml}.mztab mzTab
 	"""
 }
 
@@ -235,7 +193,7 @@ process filterPiaResults {
  * Collect all the files from search engines.
  */
 
-all_search_files = all_msgf_result.concat(all_xtandem_result)
+all_search_files = all_msgf_result.concat(all_comet_result)
 
 /**
  * Compile all the results in to one xml file.
@@ -244,8 +202,8 @@ all_search_files = all_msgf_result.concat(all_xtandem_result)
  	container 'ypriverol/pia:1.3.10'
  	publishDir "result"
 
- 	memory { 16.GB * task.attempt }
-    errorStrategy 'retry'
+ 	memory { 4.GB * task.attempt }
+    	errorStrategy 'retry'
 
  	input:
  	file(input_files) from all_search_files.collect()
@@ -255,7 +213,7 @@ all_search_files = all_msgf_result.concat(all_xtandem_result)
 
  	script:
  	"""
- 	pia -Xmx${10 * task.attempt}g compiler -infile ${(input_files as List).join(" -infile ")} -name pia-fina-complete -outfile pia-final-merged.xml
+ 	pia -Xmx${4 * task.attempt}g compiler -infile ${(input_files as List).join(" -infile ")} -name pia-fina-complete -outfile pia-final-merged.xml
  	"""
  }
 


### PR DESCRIPTION
# Features 

  * All searches done using SearchGUI
  * X!Tandem replaced by Tide

# Issues

  * PIA currently fails. Tries to access Comet result through an SQLite database?
  * PIA config needs to be adapted for Comet scores